### PR TITLE
Fix out-of-bounds read UB without variably sized memcpy

### DIFF
--- a/src/teju/fmt.rs
+++ b/src/teju/fmt.rs
@@ -138,7 +138,7 @@ pub const unsafe fn print_u64_mantissa_known_len(x: u64, buf: *mut u8, len: usiz
         }
 
         // TODO build directly in buf? But then we'd have to branch
-        let mut digits = [MaybeUninit::<u8>::uninit(); 20];
+        let mut digits = [MaybeUninit::<u8>::uninit(); 40];
         let digits_ptr = digits.as_mut_ptr() as *mut u8;
         let top12 = x / 100000000u64;
         let top4 = x / 10000000000000000u64;


### PR DESCRIPTION
This is an alternative to #2 that fixes #1 in a different way. #2 introduces a memcpy of a variable number of bytes, which may perform worse than a memcpy of a compile-time known size. This PR instead keeps the memcpy as always 20 bytes, but grows the stack buffer being copied from to ensure that `digits_ptr.add(offset).add(20)` will always be in-bounds of the same stack allocation.